### PR TITLE
Added another vpnc-script path to support debian package vpnc-scripts

### DIFF
--- a/src/mole/cmd/mole/vpnc-script.go
+++ b/src/mole/cmd/mole/vpnc-script.go
@@ -83,8 +83,10 @@ add_route() {
 
 {add_cmds}
 
-[ -f /usr/local/etc/vpnc/vpnc-script ] && /usr/local/etc/vpnc/vpnc-script
-[ -f /etc/vpnc/vpnc-script ] && /etc/vpnc/vpnc-script
+[ -f /usr/local/etc/vpnc/vpnc-script ] && VPNC_SCRIPT=/usr/local/etc/vpnc/vpnc-script
+[ -f /etc/vpnc/vpnc-script ] && VPNC_SCRIPT=/etc/vpnc/vpnc-script
+[ -f /usr/share/vpnc-scripts/vpnc-script ] && VPNC_SCRIPT=/usr/share/vpnc-scripts/vpnc-script
+[ ! -z $VPNC_SCRIPT ] && $VPNC_SCRIPT
 
 if [ "$reason" == "connect" ] ; then
 	echo mole-vpnc-script-next


### PR DESCRIPTION
vpnc-script is not bundled into vpnc package anymore (jessie+ onwards) but available as a separate package (vpnc-scripts).
Also changed the execution so that only one vpnc-script will be executed if more than one found.