### PR TITLE
Bugfix: Don't cleanup hosts for foobar when connecting to foo

### DIFF
--- a/src/mole/hosts/hosts.go
+++ b/src/mole/hosts/hosts.go
@@ -36,7 +36,7 @@ func ReplaceTagged(tag string, entries []Entry) error {
 		}
 
 		line := string(bs)
-		if !strings.Contains(line, "#tag:"+tag) {
+		if !strings.HasSuffix(line, "#tag:"+tag) {
 			lines = append(lines, line)
 		}
 	}


### PR DESCRIPTION
If you are connected to a tunnel named foobar, and connect to another named foo, this will delete all the /etc/hosts definitions for foobar. This fix checks the entire suffix instead of checking that it's part of the suffix.